### PR TITLE
Enable running integration tests in circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
       - run:
           name: Wait for Postgres to be ready
           command: ./postgres-check.sh
-      - run:
-          name: Wait for Postgres to be ready
-          command: ./postgres-check.sh
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
       _JAVA_OPTIONS: -Xmx500m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
-      - run:
-          name: Wait for Postgres to be ready
-          command: ./postgres-check.sh
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,44 @@ parameters:
 jobs:
   validate:
     executor:
-      name: hmpps/java
-      tag: "21.0"
+      name: hmpps/java_postgres
+      jdk_tag: "21.0"
+      postgres_tag: "15"
+      postgres_username: "visit_scheduler"
+      postgres_password: "visit_scheduler"
+    environment:
+      _JAVA_OPTIONS: -Xmx500m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
+      - run:
+          name: Wait for Postgres to be ready
+          command: ./postgres-check.sh
+      - run:
+          name: Wait for Postgres to be ready
+          command: ./postgres-check.sh
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
+      - hmpps/wait_till_ready_postgres
       - run:
+          name: Install git and flyway
+          command: |
+            sudo apt-get update && sudo apt-get install -y git
+            curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/8.5.10/flyway-commandline-8.5.10-linux-x64.tar.gz -o flyway.tar.gz
+            tar -xzf flyway.tar.gz
+            sudo ln -s `pwd`/flyway-8.5.10/flyway /usr/local/bin/flyway
+      - run:
+          name: Get flyway migrations from visit-scheduler
+          command: |
+            git clone https://github.com/ministryofjustice/visit-scheduler.git
+            cp -r visit-scheduler/migrations ./migrations
+      - run:
+          name: Run migrations
+          command: |
+            flyway -url=jdbc:postgresql://localhost:5432/visit_scheduler -user=visit_scheduler -password=visit_scheduler -locations=filesystem:./migrations migrate
+      - run:
+          name: Run checkstyle and integration tests
           command: ./gradlew check
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Get flyway migrations from visit-scheduler
           command: |
             git clone https://github.com/ministryofjustice/visit-scheduler.git
-            cp -r visit-scheduler/db.migrations ./migrations
+            cp -r visit-scheduler/src/main/resources/db/migrations ./migrations
       - run:
           name: Run migrations
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       postgres_tag: "15"
       postgres_username: "visit_scheduler"
       postgres_password: "visit_scheduler"
+      postgres_db: "visit_scheduler"
     environment:
       _JAVA_OPTIONS: -Xmx500m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Get flyway migrations from visit-scheduler
           command: |
             git clone https://github.com/ministryofjustice/visit-scheduler.git
-            cp -r visit-scheduler/migrations ./migrations
+            cp -r visit-scheduler/db.migrations ./migrations
       - run:
           name: Run migrations
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Get flyway migrations from visit-scheduler
           command: |
             git clone https://github.com/ministryofjustice/visit-scheduler.git
-            cp -r visit-scheduler/src/main/resources/db/migrations ./migrations
+            cp -r visit-scheduler/src/main/resources/db/migration ./migrations
       - run:
           name: Run migrations
           command: |

--- a/postgres-check.sh
+++ b/postgres-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+checked=0
+while [ ! $(netstat -na | grep '0.0.0.0.5432 ') ] && [ $checked -lt 10 ];
+do
+  echo 'Checked port 5432 to see if Postgres is up - not yet'
+  sleep 5
+  ((checked += 1))
+done
+netstat -na | grep '0.0.0.0.5432 '


### PR DESCRIPTION
The service needs knowledge of the visit-scheduler db structure. This pr allows us to pull the migrations from the public visit-scheduler repo and run them in this pipeline to get a temporary db ready for integration tests.

WIP - Syntax may not be correct, work in progress and may change